### PR TITLE
Need a mechanism to determine build's state (based on the build ID) (…

### DIFF
--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -20,8 +20,8 @@ use lazy_static::lazy_static;
 use pyrsia::cli_commands::config;
 use pyrsia::cli_commands::node;
 use pyrsia::node_api::model::cli::{
-    RequestAddAuthorizedNode, RequestDockerBuild, RequestDockerLog, RequestMavenBuild,
-    RequestMavenLog,
+    RequestAddAuthorizedNode, RequestBuildStatus, RequestDockerBuild, RequestDockerLog,
+    RequestMavenBuild, RequestMavenLog,
 };
 use regex::Regex;
 use serde_json::Value;
@@ -152,6 +152,24 @@ pub async fn request_maven_build(gav: &str) {
     })
     .await;
     handle_request_build_result(build_result);
+}
+
+pub async fn request_build_status(build_id: &str) {
+    let result = node::request_build_status(RequestBuildStatus {
+        build_id: String::from(build_id),
+    })
+    .await;
+
+    match result {
+        Ok(build_status) => println!("Build status for '{}' is '{}'", build_id, build_status),
+        Err(_) => {
+            println!(
+                "Build status for '{}' was not found. Additional info related to the build might \
+            be available via 'pyrsia inspect-log' command.",
+                build_id
+            );
+        }
+    }
 }
 
 fn handle_request_build_result(build_result: Result<String, reqwest::Error>) {

--- a/pyrsia_cli/src/cli/parser.rs
+++ b/pyrsia_cli/src/cli/parser.rs
@@ -48,6 +48,12 @@ pub fn cli_parser() -> ArgMatches {
                         .args(&[
                             arg!(--gav <GAV> "The maven GAV (e.g. org.myorg:my-artifact:1.1.0)"),
                         ]),
+                    Command::new("status")
+                        .about("Request a build status")
+                        .arg_required_else_help(true)
+                        .args(&[
+                            arg!(--id <ID> "The build ID"),
+                        ]),
                 ]),
             Command::new("config")
                 .short_flag('c')

--- a/pyrsia_cli/src/main.rs
+++ b/pyrsia_cli/src/main.rs
@@ -69,6 +69,9 @@ async fn main() {
             Some(("maven", maven_matches)) => {
                 request_maven_build(maven_matches.get_one::<String>("gav").unwrap()).await;
             }
+            Some(("status", status_matches)) => {
+                request_build_status(status_matches.get_one::<String>("id").unwrap()).await;
+            }
             _ => {}
         },
         Some(("list", _config_matches)) => {

--- a/src/build_service/error.rs
+++ b/src/build_service/error.rs
@@ -43,4 +43,6 @@ pub enum BuildError {
     PipelineServiceEndpointFailure(StatusCode),
     #[error("Failed to connect to pipeline service endpoint: {0}")]
     PipelineServiceEndpointRequestFailure(String),
+    #[error("Failed to fetch build status: {0}")]
+    BuildStatusFailed(String),
 }

--- a/src/build_service/event.rs
+++ b/src/build_service/event.rs
@@ -17,7 +17,7 @@
 use crate::artifact_service::model::PackageType;
 use crate::artifact_service::service::ArtifactService;
 use crate::build_service::error::BuildError;
-use crate::build_service::model::{BuildResult, BuildTrigger};
+use crate::build_service::model::{BuildResult, BuildStatus, BuildTrigger};
 use crate::build_service::service::BuildService;
 use crate::verification_service::service::VerificationService;
 use log::{debug, error, warn};
@@ -28,6 +28,10 @@ pub enum BuildEvent {
     Failed {
         build_id: String,
         build_error: BuildError,
+    },
+    Status {
+        build_id: String,
+        sender: oneshot::Sender<Result<String, BuildError>>,
     },
     Start {
         package_type: PackageType,
@@ -105,6 +109,22 @@ impl BuildEventClient {
         receiver
             .await
             .map_err(|e| BuildError::InitializationFailed(e.to_string()))?
+    }
+
+    pub async fn get_build_status(&self, build_id: &str) -> Result<String, BuildError> {
+        let (sender, receiver) = oneshot::channel();
+        self.build_event_sender
+            .send(BuildEvent::Status {
+                build_id: String::from(build_id),
+                sender,
+            })
+            .await
+            .unwrap_or_else(|e| {
+                error!("Error build_event_sender. {:#?}", e);
+            });
+        receiver
+            .await
+            .map_err(|e| BuildError::BuildStatusFailed(e.to_string()))?
     }
 
     pub async fn build_succeeded(
@@ -237,6 +257,22 @@ impl BuildEventLoop {
 
                 self.verification_service
                     .handle_build_failed(&build_id, build_error);
+            }
+            BuildEvent::Status { build_id, sender } => {
+                let result = match self.build_service.get_build_status(&build_id).await {
+                    Ok(build_info) => {
+                        let build_status = match build_info.status {
+                            BuildStatus::Running => String::from("RUNNING"),
+                            BuildStatus::Success { .. } => String::from("SUCCESS"),
+                            BuildStatus::Failure(_) => String::from("FAILED"),
+                        };
+                        Ok(build_status)
+                    }
+                    Err(build_error) => Err(build_error),
+                };
+                sender.send(result).unwrap_or_else(|build_error| {
+                    error!("build error. {:#?}", build_error);
+                });
             }
             BuildEvent::Succeeded {
                 build_id,

--- a/src/build_service/pipeline/service.rs
+++ b/src/build_service/pipeline/service.rs
@@ -74,7 +74,9 @@ impl PipelineService {
             .await
             .map_err(|e| BuildError::PipelineServiceEndpointRequestFailure(e.to_string()))?;
 
-        if get_build_status_response.status().is_success() {
+        let response = get_build_status_response.status();
+
+        if response.is_success() {
             get_build_status_response
                 .json::<BuildInfo>()
                 .await

--- a/src/build_service/service.rs
+++ b/src/build_service/service.rs
@@ -20,6 +20,7 @@ use super::mapping::service::MappingService;
 use super::model::{BuildResult, BuildResultArtifact, BuildStatus, BuildTrigger};
 use super::pipeline::service::PipelineService;
 use crate::artifact_service::model::PackageType;
+use crate::build_service::model::BuildInfo;
 use bytes::Buf;
 use log::{debug, error, warn};
 use multihash::Hasher;
@@ -256,6 +257,10 @@ impl BuildService {
                 build_path, error
             )
         }
+    }
+
+    pub async fn get_build_status(&self, build_id: &str) -> Result<BuildInfo, BuildError> {
+        self.pipeline_service.get_build_status(build_id).await
     }
 
     fn get_build_path(&self, build_id: &str) -> PathBuf {

--- a/src/cli_commands/node.rs
+++ b/src/cli_commands/node.rs
@@ -16,8 +16,8 @@
 
 use super::config::get_config;
 use crate::node_api::model::cli::{
-    RequestAddAuthorizedNode, RequestDockerBuild, RequestDockerLog, RequestMavenBuild,
-    RequestMavenLog, Status,
+    RequestAddAuthorizedNode, RequestBuildStatus, RequestDockerBuild, RequestDockerLog,
+    RequestMavenBuild, RequestMavenLog, Status,
 };
 
 pub async fn ping() -> Result<String, reqwest::Error> {
@@ -55,6 +55,22 @@ pub async fn add_authorized_node(request: RequestAddAuthorizedNode) -> Result<()
 pub async fn request_docker_build(request: RequestDockerBuild) -> Result<String, reqwest::Error> {
     let node_url = format!("http://{}/build/docker", get_url());
     let client = reqwest::Client::new();
+    match client
+        .post(node_url)
+        .json(&request)
+        .send()
+        .await?
+        .error_for_status()
+    {
+        Ok(response) => response.json::<String>().await,
+        Err(e) => Err(e),
+    }
+}
+
+pub async fn request_build_status(request: RequestBuildStatus) -> Result<String, reqwest::Error> {
+    let node_url = format!("http://{}/build/status", get_url());
+    let client = reqwest::Client::new();
+
     match client
         .post(node_url)
         .json(&request)

--- a/src/network.rs
+++ b/src/network.rs
@@ -22,3 +22,4 @@ pub mod client;
 pub mod event_loop;
 pub mod idle_metric_protocol;
 pub mod p2p;
+pub mod build_status_protocol;

--- a/src/network/behaviour.rs
+++ b/src/network/behaviour.rs
@@ -29,6 +29,7 @@ use libp2p::kad::record::store::MemoryStore;
 use libp2p::kad::{Kademlia, KademliaEvent};
 use libp2p::request_response::{RequestResponse, RequestResponseEvent};
 use libp2p::NetworkBehaviour;
+use crate::network::build_status_protocol::{BuildStatusExchangeCodec, BuildStatusRequest, BuildStatusResponse};
 
 /// Defines the [`NetworkBehaviour`] to be used in the libp2p
 /// Swarm. The PyrsiaNetworkBehaviour consists of the following
@@ -48,6 +49,7 @@ pub struct PyrsiaNetworkBehaviour {
     pub build_request_response: RequestResponse<BuildExchangeCodec>,
     pub idle_metric_request_response: RequestResponse<IdleMetricExchangeCodec>,
     pub blockchain_request_response: RequestResponse<BlockchainExchangeCodec>,
+    pub build_status_request_response: RequestResponse<BuildStatusExchangeCodec>,
 }
 
 /// Each event in the `PyrsiaNetworkBehaviour` is wrapped in a
@@ -61,6 +63,7 @@ pub enum PyrsiaNetworkEvent {
     BuildRequestResponse(RequestResponseEvent<BuildRequest, BuildResponse>),
     IdleMetricRequestResponse(RequestResponseEvent<IdleMetricRequest, IdleMetricResponse>),
     BlockchainRequestResponse(RequestResponseEvent<BlockchainRequest, BlockchainResponse>),
+    BuildStatusRequestResponse(RequestResponseEvent<BuildStatusRequest, BuildStatusResponse>),
 }
 
 impl From<autonat::Event> for PyrsiaNetworkEvent {
@@ -102,5 +105,11 @@ impl From<RequestResponseEvent<IdleMetricRequest, IdleMetricResponse>> for Pyrsi
 impl From<RequestResponseEvent<BlockchainRequest, BlockchainResponse>> for PyrsiaNetworkEvent {
     fn from(event: RequestResponseEvent<BlockchainRequest, BlockchainResponse>) -> Self {
         PyrsiaNetworkEvent::BlockchainRequestResponse(event)
+    }
+}
+
+impl From<RequestResponseEvent<BuildStatusRequest, BuildStatusResponse>> for PyrsiaNetworkEvent {
+    fn from(event: RequestResponseEvent<BuildStatusRequest, BuildStatusResponse>) -> Self {
+        PyrsiaNetworkEvent::BuildStatusRequestResponse(event)
     }
 }

--- a/src/network/build_status_protocol.rs
+++ b/src/network/build_status_protocol.rs
@@ -1,0 +1,128 @@
+/*
+   Copyright 2021 JFrog Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use crate::artifact_service::model::PackageType;
+use async_trait::async_trait;
+use futures::prelude::*;
+use libp2p::core::upgrade::{read_length_prefixed, write_length_prefixed, ProtocolName};
+use libp2p::request_response::RequestResponseCodec;
+use log::debug;
+use std::io;
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub struct BuildStatusExchangeProtocol();
+/// The `BuildExchangeCodec` defines the request and response types
+/// for the [`RequestResponse`](crate::RequestResponse) protocol for
+/// exchanging builds. At the moment, the implementation for
+/// encoding/decoding writes all bytes of a single artifact at once.
+#[derive(Clone)]
+pub struct BuildStatusExchangeCodec();
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildStatusRequest(pub String);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildStatusResponse(pub String);
+
+impl ProtocolName for BuildStatusExchangeProtocol {
+    fn protocol_name(&self) -> &[u8] {
+        "/build-status-exchange/1".as_bytes()
+    }
+}
+
+#[async_trait]
+impl RequestResponseCodec for BuildStatusExchangeCodec {
+    type Protocol = BuildStatusExchangeProtocol;
+    type Request = BuildStatusRequest;
+    type Response = BuildStatusResponse;
+
+    async fn read_request<T>(
+        &mut self,
+        _: &BuildStatusExchangeProtocol,
+        io: &mut T,
+    ) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        debug!("Reading BuildStatusRequest...");
+
+        let hash_vec0 = read_length_prefixed(io, 1_000_000).await?;
+        if hash_vec0.is_empty() {
+            return Err(io::ErrorKind::UnexpectedEof.into());
+        }
+
+        let build_id = String::from_utf8(hash_vec0).unwrap();
+
+        let hash_vec1 = read_length_prefixed(io, 1_000_000).await?;
+        if hash_vec1.is_empty() {
+            return Err(io::ErrorKind::UnexpectedEof.into());
+        }
+
+        Ok(BuildStatusRequest(build_id))
+    }
+
+    async fn read_response<T>(
+        &mut self,
+        _: &BuildStatusExchangeProtocol,
+        io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let hash_vec = read_length_prefixed(io, 1_000_000).await?;
+        if hash_vec.is_empty() {
+            return Err(io::ErrorKind::UnexpectedEof.into());
+        }
+
+        let status = String::from_utf8(hash_vec).unwrap();
+
+        Ok(BuildStatusResponse(status))
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        _: &BuildStatusExchangeProtocol,
+        io: &mut T,
+        BuildStatusRequest(build_id): BuildStatusRequest,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        debug!(
+            "Write BuildStatusRequest: build_id: {:?}", build_id
+        );
+
+        write_length_prefixed(io, build_id.to_string()).await?;
+        io.close().await?;
+
+        Ok(())
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        _: &BuildStatusExchangeProtocol,
+        io: &mut T,
+        BuildStatusResponse(status): BuildStatusResponse,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        debug!("Write BuildResponse: {}", status);
+
+        write_length_prefixed(io, status).await?;
+
+        Ok(())
+    }
+}

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -357,6 +357,28 @@ impl Client {
 
         Ok(())
     }
+
+    pub async fn request_build_status(
+        &mut self,
+        peer_id: &PeerId,
+        build_id: String,
+    ) -> anyhow::Result<String> {
+        debug!(
+            "p2p::Client::request_build_status peer_id {:?}, build_id: {:?}",
+            peer_id, build_id
+        );
+
+        let (sender, receiver) = oneshot::channel();
+        self.sender
+            .send(Command::RequestBuildStatus {
+                peer: *peer_id,
+                build_id,
+                sender,
+            })
+            .await?;
+
+        receiver.await?
+    }
 }
 
 #[cfg(test)]

--- a/src/network/client/command.rs
+++ b/src/network/client/command.rs
@@ -95,6 +95,11 @@ pub enum Command {
         data: Vec<u8>,
         channel: ResponseChannel<BlockchainResponse>,
     },
+    RequestBuildStatus {
+        peer: PeerId,
+        build_id: String,
+        sender: oneshot::Sender<anyhow::Result<String>>,
+    },
 }
 
 #[cfg(test)]

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -36,6 +36,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::Stream;
+use crate::network::build_status_protocol::{BuildStatusExchangeCodec, BuildStatusExchangeProtocol};
 
 /// Sets up the libp2p [`Swarm`] with the necessary components, doing the following things:
 ///
@@ -203,6 +204,11 @@ fn create_swarm(
                 blockchain_request_response: RequestResponse::new(
                     BlockchainExchangeCodec(),
                     iter::once((BlockchainExchangeProtocol(), ProtocolSupport::Full)),
+                    Default::default(),
+                ),
+                build_status_request_response: RequestResponse::new(
+                    BuildStatusExchangeCodec(),
+                    iter::once((BuildStatusExchangeProtocol(), ProtocolSupport::Full)),
                     Default::default(),
                 ),
             },

--- a/src/node_api/model/cli.rs
+++ b/src/node_api/model/cli.rs
@@ -47,3 +47,8 @@ pub struct RequestMavenBuild {
 pub struct RequestMavenLog {
     pub gav: String,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RequestBuildStatus {
+    pub build_id: String,
+}


### PR DESCRIPTION
…#1254)

This issues implements a new feature described in #1254, The idea is that users can check the status of the requested build.

## Description

New feature added to track the requested build state, from the user perspective the following CLI commands were added:

`pyrsia build status --id <BUILD ID>`

Few examples of returned messages:
`Build status for 'b024a136-9021-42a1-b8de-c665c94470f4' is 'SUCCESS'`
`Build status for 'f1548c9a-f2ee-46b9-8993-eed0a8e5c239' is 'FAILED'`

When the build ID is not found or expired:
`Build status for 'b024a136-9021-42a1-b8de-c665c94470f4' was not found. Additional info related to the build might be available via 'pyrsia inspect-log' command.`

Fixes pyrsia/pyrsia#

This issues implements a new feature described here: 


## PR Checklist

<!-- Make certain you've done the following. -->

- [ ] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [ ] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [ ] I've included a good title and brief description along with how to review them.
- [ ] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer PR guidlines](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/submit_pr.md)!

-->

- [ ] I've built the code `cargo build --all-targets` successfully.
- [ ] I've run the unit tests `cargo test --workspace` and everything passes.
